### PR TITLE
riscv: dts: starfive: jh7100: Refer to labels from aliases

### DIFF
--- a/arch/riscv/boot/dts/starfive/jh7100.dtsi
+++ b/arch/riscv/boot/dts/starfive/jh7100.dtsi
@@ -8,10 +8,10 @@
 	compatible = "starfive,jh7100";
 
 	aliases {
-		spi0 = "/soc/spi@11860000";
-		mshc0 = "/soc/mmc@10000000";
-		mshc1 = "/soc/mmc@10010000";
-		usb0 = "/soc/usb@104c0000";
+		spi0 = &qspi;
+		mshc0 = &sdio0;
+		mshc1 = &sdio1;
+		usb0 = &usb3;
 	};
 
 	chosen {


### PR DESCRIPTION
Let the aliases refer to device nodes using their labels, instead of
absolute paths.

Fixes: 3ca51334ce06a93f ("riscv: dts: Add JH7100 and BeagleV Starlight support")
Signed-off-by: Geert Uytterhoeven <geert@linux-m68k.org>