### PR TITLE
drivers/usb: Don't flush NULL values

### DIFF
--- a/include/linux/usb.h
+++ b/include/linux/usb.h
@@ -1617,9 +1617,8 @@ static inline void cdns_flush_dcache(unsigned long start, unsigned long len)
 
 static inline void cdns_virt_flush_dcache(void *virt_start, unsigned long len)
 {
-	unsigned long start = dw_virt_to_phys(virt_start);
-
-	starfive_flush_dcache(_ALIGN_DOWN(start, 64), len + (start & 63));
+	if (virt_start != NULL)
+		cdns_flush_dcache(dw_virt_to_phys(virt_start), len);
 }
 #endif
 /* ----------------------------------------------------------------------- */


### PR DESCRIPTION
When plugging in USB storage we get many warning reports such as:

    L2CACHE: flush64 out of range: 2080200000(20000), skip flush
    L2CACHE: flush64 out of range: 2080200000(20000), skip flush

Adding some debug statements points to the following stack trace:

    Call Trace:
    [<ffffffff803a2c36>] sifive_l2_flush64_range+0x8e/0xaa
    [<ffffffff804ea6f4>] uas_alloc_data_urb.constprop.0+0x72/0xb2
    [<ffffffff804ea876>] uas_submit_urbs+0x142/0x3ce
    [<ffffffff804eacb6>] uas_queuecommand+0xe2/0x1f6
    [<ffffffff80437352>] scsi_queue_rq+0x2f2/0x7de
    [<ffffffff802f8572>] blk_mq_dispatch_rq_list+0xd8/0x6fa
    [<ffffffff802fd998>] __blk_mq_sched_dispatch_requests+0xd4/0x146
    [<ffffffff802fdb2a>] blk_mq_sched_dispatch_requests+0x2c/0x56
    [<ffffffff802f700e>] __blk_mq_run_hw_queue+0x4c/0x74
    [<ffffffff802f71be>] __blk_mq_delay_run_hw_queue+0x188/0x18e
    [<ffffffff802f845e>] blk_mq_run_hw_queue+0x6c/0xa8
    ...

The issue is that uas_alloc_data_urb() calls usb_fill_bulk_urb() with a
NULL buffer pointer and the dcache flush code tries to flush it causing
the above warnings.

This patch adds a check to ignore flush requests for NULL and 0 values.

Fixes: 1ab9c4c0f8e3 ("drivers/usb: Add dcache flush(VIC7100 ONLY)")
Signed-off-by: Stafford Horne <shorne@gmail.com>