### PR TITLE
dt-bindings: gpio: fix starfive,jh7100-gpio bindings example

### DIFF
--- a/Documentation/devicetree/bindings/gpio/starfive,jh7100-gpio.yaml
+++ b/Documentation/devicetree/bindings/gpio/starfive,jh7100-gpio.yaml
@@ -47,19 +47,14 @@ additionalProperties: false
 
 examples:
   - |
-      soc {
-        #address-cells = <2>;
-        #size-cells = <2>;
-
-        gpio@11910000 {
-          compatible = "starfive,jh7100-gpio";
-          reg = <0x0 0x11910000 0x0 0x10000>;
-          gpio-controller;
-          #gpio-cells = <2>;
-          interrupt-controller;
-          #interrupt-cells = <2>;
-          interrupts = <32>;
-        };
+      gpio@11910000 {
+        compatible = "starfive,jh7100-gpio";
+        reg = <0x11910000 0x10000>;
+        gpio-controller;
+        #gpio-cells = <2>;
+        interrupt-controller;
+        #interrupt-cells = <2>;
+        interrupts = <32>;
       };
 
 ...


### PR DESCRIPTION
In the example, drop surrounding "soc" node and `#{address,size}-cells`.  By convention, all examples on MMIO bus use `#{address,size}-cells = <1>`.

@geertu hopefully I have finally gotten this right.  Thank you for your help.

```
pdp7@x1:~/dev/starfive/linux$ make -j8 ARCH=riscv CROSS_COMPILE=riscv64-linux-gnu- dtbs_check DT_SCHEMA_FILES=Documentation/devicetree/bindings/gpio/starfive,jh7100-gpio.yaml
  SYNC    include/config/auto.conf.cmd
  HOSTCC  scripts/kconfig/conf.o
  HOSTCC  scripts/kconfig/confdata.o
  HOSTCC  scripts/kconfig/expr.o
  LEX     scripts/kconfig/lexer.lex.c
  YACC    scripts/kconfig/parser.tab.[ch]
  HOSTCC  scripts/kconfig/menu.o
  HOSTCC  scripts/kconfig/preprocess.o
  HOSTCC  scripts/kconfig/symbol.o
  HOSTCC  scripts/kconfig/util.o
  HOSTCC  scripts/kconfig/lexer.lex.o
  HOSTCC  scripts/kconfig/parser.tab.o
  HOSTLD  scripts/kconfig/conf
  SCHEMA  Documentation/devicetree/bindings/processed-schema.json
  UPD     include/config/kernel.release
  DTC     arch/riscv/boot/dts/starfive/jh7100-starlight.dtb
  DTC     arch/riscv/boot/dts/sifive/hifive-unleashed-a00.dtb
  DTC     arch/riscv/boot/dts/sifive/hifive-unmatched-a00.dtb
  DTC     arch/riscv/boot/dts/starfive/jh7100-starlight.dt.yaml
  DTC     arch/riscv/boot/dts/sifive/hifive-unleashed-a00.dt.yaml
  DTC     arch/riscv/boot/dts/sifive/hifive-unmatched-a00.dt.yaml
  CHECK   arch/riscv/boot/dts/starfive/jh7100-starlight.dt.yaml
  CHECK   arch/riscv/boot/dts/sifive/hifive-unleashed-a00.dt.yaml
  CHECK   arch/riscv/boot/dts/sifive/hifive-unmatched-a00.dt.yaml
```

```
pdp7@x1:~/dev/starfive/linux$ make -j8 ARCH=riscv CROSS_COMPILE=riscv64-linux-gnu- dt_binding_check DT_SCHEMA_FILES=Documentation/devicetree/bindings/gpio/starfive,jh7100-gpio.yaml
  CHKDT   Documentation/devicetree/bindings/processed-schema-examples.json
  DTEX    Documentation/devicetree/bindings/gpio/starfive,jh7100-gpio.example.dts
  SCHEMA  Documentation/devicetree/bindings/processed-schema-examples.json
  DTC     Documentation/devicetree/bindings/gpio/starfive,jh7100-gpio.example.dt.yaml
  CHECK   Documentation/devicetree/bindings/gpio/starfive,jh7100-gpio.example.dt.yaml
```