### PR TITLE
add starifve jh7100 yaml dt schema

### DIFF
--- a/Documentation/devicetree/bindings/riscv/starfive.yaml
+++ b/Documentation/devicetree/bindings/riscv/starfive.yaml
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/riscv/starfive.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
+
+title: StarFive SoC-based boards
+
+maintainers:
+  - Michael Zhu <michael.zhu@starfivetech.com>
+  - Drew Fustini <drew@beagleboard.org>
+
+description:
+  SiFive SoC-based boards
+
+properties:
+  $nodename:
+    const: '/'
+  compatible:
+    oneOf:
+      - items:
+          - const: beagle,beaglev-starlight-jh7100
+          - const: starfive,jh7100
+
+      - items:
+          - const: starfive,jh7100
+
+additionalProperties: true
+
+...

--- a/arch/riscv/boot/dts/starfive/jh7100.dtsi
+++ b/arch/riscv/boot/dts/starfive/jh7100.dtsi
@@ -84,7 +84,7 @@
 	};
 
 	soc {
-		compatible = "starfive,jh7100", "simple-bus";
+		compatible = "simple-bus";
 		interrupt-parent = <&plic>;
 		#address-cells = <2>;
 		#size-cells = <2>;


### PR DESCRIPTION
Add DT schema for the StarFive JH7100 Soc and the BeagleV Starlight JH7100 board bindings.

```
$ make -j8 ARCH=riscv CROSS_COMPILE=riscv64-linux-gnu- dt_binding_check DT_SCHEMA_FILES=Documentation/devicetree/bindings/riscv/starfive.yaml 
  CHKDT   Documentation/devicetree/bindings/processed-schema-examples.json
  SCHEMA  Documentation/devicetree/bindings/processed-schema-examples.json
  DTC     Documentation/devicetree/bindings/riscv/starfive.example.dt.yaml
  CHECK   Documentation/devicetree/bindings/riscv/starfive.example.dt.yaml

$ make -j8 ARCH=riscv CROSS_COMPILE=riscv64-linux-gnu- dtbs_check DT_SCHEMA_FILES=Documentation/devicetree/bindings/riscv/starfive.yaml
  SCHEMA  Documentation/devicetree/bindings/processed-schema.json
  DTC     arch/riscv/boot/dts/sifive/hifive-unleashed-a00.dt.yaml
  DTC     arch/riscv/boot/dts/starfive/jh7100-beaglev-starlight.dt.yaml
  DTC     arch/riscv/boot/dts/sifive/hifive-unmatched-a00.dt.yaml
  CHECK   arch/riscv/boot/dts/sifive/hifive-unleashed-a00.dt.yaml
  CHECK   arch/riscv/boot/dts/sifive/hifive-unmatched-a00.dt.yaml
  CHECK   arch/riscv/boot/dts/starfive/jh7100-beaglev-starlight.dt.yaml
```






